### PR TITLE
Fix a server user connection issue

### DIFF
--- a/XP Benefits/src/Mods/UserCode/XP Benefits/Core/BenefitDynamicValue.cs
+++ b/XP Benefits/src/Mods/UserCode/XP Benefits/Core/BenefitDynamicValue.cs
@@ -13,7 +13,7 @@ namespace XPBenefits
 
         public BenefitDynamicValue(IBenefitFunction benefitFunction)
         {
-            BenefitFunction = benefitFunction ?? throw new ArgumentNullException(nameof(benefitFunction));
+            BenefitFunction = benefitFunction;
         }
 
         public float GetCurrentValue(IDynamicValueContext context, object obj)


### PR DESCRIPTION
## Context

See: https://discord.com/channels/254025510651297802/735376557027229768/1324066952494321735

## The Error

```

System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'benefitFunction')
   at XPBenefits.BenefitDynamicValue..ctor(IBenefitFunction benefitFunction) in /home/kai/Steam/steamapps/common/EcoServer/Mods/UserCode/XP Benefits/Core/BenefitDynamicValue.cs:line 16
   at XPBenefits.ExtraWeightLimitBenefit.ApplyBenefitToUser(User user) in /home/kai/Steam/steamapps/common/EcoServer/Mods/UserCode/XP Benefits/Benefits/ExtraWeightLimitBenefit.cs:line 48
   at XPBenefits.RegisterExtraWeightLimitBenefit.<>c__DisplayClass2_0.<Initialize>b__0(User user) in /home/kai/Steam/steamapps/common/EcoServer/Mods/UserCode/XP Benefits/Benefits/ExtraWeightLimitBenefit.cs:line 28
   at Eco.Core.Utils.ThreadSafeAction`1.Invoke(T t)
   at Eco.Gameplay.Players.User.LoginCompleted()
   at Eco.Plugins.Networking.Client.SpawnPlayer(Single viewDistance, String language)
   at InvokeStub_Client.SpawnPlayer(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Eco.Shared.Networking.RPCInvocation.Invoke()
   at Eco.Shared.Networking.RPCManager.Invoke(INetClient client, RPCInvocation invocation, Boolean notifyOnPermissionFail)
   at Eco.Shared.Networking.RPCManager.InvokeOn(INetClient client, BSONObject bson, Object target, String methodName)
   at Eco.Shared.Networking.RPCManager.HandleReceiveRPC(INetClient client, BSONObject bson)
   at Eco.Plugins.Networking.NetworkServer.Eco.Shared.Networking.INetworkEventHandler.ReceiveEvent(INetClient client, NetworkEvent netEvent, BSONValue bsonValue)
Invalid queuehandle on tickable.  Is it being destroyed twice?
```

